### PR TITLE
Add factory-level limit for cached inactive pool objects

### DIFF
--- a/Source/PoolManager/Private/Data/PoolContainer.cpp
+++ b/Source/PoolManager/Private/Data/PoolContainer.cpp
@@ -34,6 +34,14 @@ FPoolObjectData* FPoolContainer::FindInPool(const FPoolObjectHandle& Handle)
 	return PoolObjects.FindByKey(Handle);
 }
 
+void FPoolContainer::RemoveInPool(const UObject& Object)
+{
+	if (const FPoolObjectData* ObjectData = FindInPool(Object))
+	{
+		PoolObjects.RemoveSingleSwap(*ObjectData);
+	}
+}
+
 // Returns factory or crashes as critical error if it is not set
 UPoolFactory_UObject& FPoolContainer::GetFactoryChecked() const
 {

--- a/Source/PoolManager/Private/PoolManagerSubsystem.cpp
+++ b/Source/PoolManager/Private/PoolManagerSubsystem.cpp
@@ -274,10 +274,21 @@ bool UPoolManagerSubsystem::ReturnToPool_Implementation(UObject* Object)
 		return false;
 	}
 
-	FPoolContainer& Pool = FindPoolOrAdd(Object->GetClass());
-	Pool.GetFactoryChecked().OnReturnToPool(Object);
+	const UClass* ObjectClass = Object->GetClass();
+	FPoolContainer& Pool = FindPoolOrAdd(ObjectClass);
+	UPoolFactory_UObject& Factory = Pool.GetFactoryChecked();
 
-	SetObjectStateInPool(EPoolObjectState::Inactive, *Object, Pool);
+	const int32 InactiveCount = GetFreeObjectsNum(ObjectClass);
+	if (InactiveCount < Factory.GetMaxCachedInactive())
+	{
+		Factory.OnReturnToPool(Object);
+		SetObjectStateInPool(EPoolObjectState::Inactive, *Object, Pool);
+	}
+	else
+	{
+		RemoveObjectInPool(*Object, Pool);
+		Factory.Destroy(Object);
+	}
 
 	return true;
 }
@@ -819,4 +830,15 @@ void UPoolManagerSubsystem::SetObjectStateInPool(EPoolObjectState NewState, UObj
 	PoolObject->bIsActive = NewState == EPoolObjectState::Active;
 
 	InPool.GetFactoryChecked().OnChangedStateInPool(NewState, &InObject);
+}
+
+void UPoolManagerSubsystem::RemoveObjectInPool(UObject& InObject, FPoolContainer& InPool)
+{
+	const FPoolObjectData* PoolObject = InPool.FindInPool(InObject);
+	if (!ensureMsgf(PoolObject && PoolObject->IsValid(), TEXT("ASSERT: [%i] %hs:\nObject is not registered or has invalid pool data for class: %s"), __LINE__, __FUNCTION__, *GetNameSafe(InPool.ObjectClass)))
+	{
+		return;
+	}
+
+	InPool.RemoveInPool(InObject);
 }

--- a/Source/PoolManager/Public/Data/PoolContainer.h
+++ b/Source/PoolManager/Public/Data/PoolContainer.h
@@ -46,6 +46,9 @@ struct POOLMANAGER_API FPoolContainer
 	FPoolObjectData* FindInPool(const struct FPoolObjectHandle& Handle);
 	const FORCEINLINE FPoolObjectData* FindInPool(const struct FPoolObjectHandle& Handle) const { return const_cast<FPoolContainer*>(this)->FindInPool(Handle); }
 
+	/** Removes the specified object from the pool registry. */
+	void RemoveInPool(const UObject& Object);
+
 	/** Returns factory or crashes as critical error if it is not set. */
 	class UPoolFactory_UObject& GetFactoryChecked() const;
 

--- a/Source/PoolManager/Public/Factories/PoolFactory_UObject.h
+++ b/Source/PoolManager/Public/Factories/PoolFactory_UObject.h
@@ -123,4 +123,24 @@ protected:
 	/** All request to spawn. */
 	UPROPERTY(VisibleInstanceOnly, BlueprintReadWrite, Transient, AdvancedDisplay, Category = "[Pool Manager]", meta = (BlueprintProtected))
 	TArray<FSpawnRequest> SpawnQueue;
+
+	/*********************************************************************************************
+	 * Pool policy
+	 ********************************************************************************************* */
+public:
+	/** Returns the maximum number of inactive objects allowed to be kept cached for this factory. */
+	FORCEINLINE int32 GetMaxCachedInactive() const { return MaxCachedInactive; }
+
+protected:
+	/**
+	 * Maximum number of inactive objects that this factory is allowed to keep cached in the pool.
+	 *
+	 * This value limits ONLY the number of objects stored in the Inactive (cached) state.
+	 * It does NOT limit object creation, spawning, or the number of active objects.
+	 * When the limit is reached, returned objects are destroyed instead of cached.
+	 *
+	 * Default is unlimited (no cache limit).
+	 */
+	UPROPERTY(VisibleInstanceOnly, BlueprintReadOnly, Transient, Category = "[Pool Manager]", meta = (BlueprintProtected))
+	int32 MaxCachedInactive = TNumericLimits<int32>::Max();
 };

--- a/Source/PoolManager/Public/PoolManagerSubsystem.h
+++ b/Source/PoolManager/Public/PoolManagerSubsystem.h
@@ -343,4 +343,18 @@ protected:
 	 * @param InPool The pool that contains the object.
 	 * @warning Do not call it directly, use TakeFromPool() or ReturnToPool() instead. */
 	virtual void SetObjectStateInPool(EPoolObjectState NewState, UObject& InObject, UPARAM(ref) FPoolContainer& InPool);
+
+	/**
+	 * Unregisters the object from the pool registry and removes it from internal pool data.
+	 *
+	 * This permanently removes the object from the Pool Manager and should be used when
+	 * the object must no longer participate in pooling (e.g. cache limit reached).
+	 *
+	 * Unlike SetObjectStateInPool(), this does NOT change the active/inactive state,
+	 * but fully detaches the object from the pooling system.
+	 *
+	 * @warning Do not call it directly from gameplay code.
+	 * Used internally by the Pool Manager when an object must be destroyed or discarded.
+	 */
+	virtual void RemoveObjectInPool(UObject& InObject, UPARAM(ref) FPoolContainer& InPool);
 };


### PR DESCRIPTION
Introduces a factory-level cache limit for inactive objects, discarding returned objects once the cache is full without affecting spawning or active usage.